### PR TITLE
Update core.py

### DIFF
--- a/components/niagads/csv_parser/core.py
+++ b/components/niagads/csv_parser/core.py
@@ -121,7 +121,7 @@ class CSVFileParser(AbstractFlatfileParser):
         try:
             if self.__delimiter is None:
                 with self.open_ctx() as fh:
-                    dialect: Dialect = Sniffer().sniff(fh.read(bytes))
+                    dialect: Dialect = Sniffer().sniff(fh.read(bytes), delimiters=[",", "\t", ";", "|"])
                     fh.seek(0)
                     self.__delimiter = dialect.delimiter
                 return self.__delimiter


### PR DESCRIPTION
added list of possible delimiters to sniffer to prevent regularly-occuring non-delimiter character from being misidentified as deliminator