### PR TITLE
Update core.py to fix data submission app bug #48

### DIFF
--- a/components/niagads/metadata_validator/core.py
+++ b/components/niagads/metadata_validator/core.py
@@ -66,9 +66,9 @@ class FileManifestValidator(CSVTableValidator):
             if fail_on_error:
                 raise error
             else:
-                validation_result["errors"].append(
-                    {f"invalid_{self.__sample_field.upper()}": invalid_samples}
-                )
+                validation_result["errors"][
+                     f"invalid_{self.__sample_field.upper()}"
+                ] = invalid_samples
 
         if len(missing_samples) > 0:
             warning = {f"no_file_for_{self.__sample_field.upper()}": missing_samples}
@@ -137,9 +137,10 @@ class BiosourcePropertiesValidator(CSVTableValidator):
             if fail_on_error:
                 raise error
             else:
-                validation_result["errors"].append(
-                    {f"duplicate_{self._biosource_id.upper()}": duplicates}
-                )
+                validation_result["errors"][
+                   f"duplicate_{self._biosource_id.upper()}"
+                ] = duplicates
+
         return validation_result
 
     def get_biosource_ids(self):


### PR DESCRIPTION
This PR fixes a bug in niagads.metadata_validator where validation errors were being added with .append() even though the validator’s errors field is a dict. That mismatch caused metadata validation to crash whenever duplicate biosource IDs or invalid sample references were encountered.

- Prevents AttributeError: 'dict' object has no attribute 'append' during validation.